### PR TITLE
[Treemap] Errors with very small nodes

### DIFF
--- a/Source/Layouts/Layouts.TM.js
+++ b/Source/Layouts/Layouts.TM.js
@@ -341,7 +341,7 @@ Layouts.TM.Squarified = new Class({
    $.each(ch, function(elem) { totalArea += elem._area; });
    var width = w == 0 ? 0 : rnd(totalArea / w), top =  0;
    for(var i=0, l=ch.length; i<l; i++) {
-     var h = rnd(ch[i]._area / width);
+     var h = width == 0 ? 0 : rnd(ch[i]._area / width);
      var chi = ch[i];
      chi.getPos(prop).setc(coord.left, coord.top + top);
      chi.setData('width', width, prop);

--- a/Source/Layouts/Layouts.TM.js
+++ b/Source/Layouts/Layouts.TM.js
@@ -339,7 +339,7 @@ Layouts.TM.Squarified = new Class({
  layoutV: function(ch, w, coord, prop) {
    var totalArea = 0, rnd = function(x) { return x; }; 
    $.each(ch, function(elem) { totalArea += elem._area; });
-   var width = rnd(totalArea / w), top =  0; 
+   var width = w == 0 ? 0 : rnd(totalArea / w), top =  0;
    for(var i=0, l=ch.length; i<l; i++) {
      var h = rnd(ch[i]._area / width);
      var chi = ch[i];
@@ -363,13 +363,13 @@ Layouts.TM.Squarified = new Class({
  layoutH: function(ch, w, coord, prop) {
    var totalArea = 0; 
    $.each(ch, function(elem) { totalArea += elem._area; });
-   var height = totalArea / w,
+   var height = w == 0 ? 0 : totalArea / w,
        top = coord.top, 
        left = 0;
    
    for(var i=0, l=ch.length; i<l; i++) {
      var chi = ch[i];
-     var w = chi._area / height;
+     var w = height == 0 ? 0 : chi._area / height;
      chi.getPos(prop).setc(coord.left + left, top);
      chi.setData('width', w, prop);
      chi.setData('height', height, prop);

--- a/Source/Layouts/Layouts.TM.js
+++ b/Source/Layouts/Layouts.TM.js
@@ -336,12 +336,12 @@ Layouts.TM.Squarified = new Class({
    }
  },
  
- layoutV: function(ch, w, coord, prop) {
-   var totalArea = 0, rnd = function(x) { return x; }; 
+layoutV: function(ch, w, coord, prop) {
+   var totalArea = 0, rnd = function(x) { return x; };
    $.each(ch, function(elem) { totalArea += elem._area; });
-   var width = w == 0 ? 0 : rnd(totalArea / w), top =  0;
+   var width = rnd(totalArea / w) || 0, top =  0;
    for(var i=0, l=ch.length; i<l; i++) {
-     var h = width == 0 ? 0 : rnd(ch[i]._area / width);
+     var h = rnd(ch[i]._area / width) || 0;
      var chi = ch[i];
      chi.getPos(prop).setc(coord.left, coord.top + top);
      chi.setData('width', width, prop);
@@ -359,17 +359,17 @@ Layouts.TM.Squarified = new Class({
    if(ans.dim != ans.height) this.layout.change();
    return ans;
  },
- 
+
  layoutH: function(ch, w, coord, prop) {
-   var totalArea = 0; 
+   var totalArea = 0;
    $.each(ch, function(elem) { totalArea += elem._area; });
-   var height = w == 0 ? 0 : totalArea / w,
-       top = coord.top, 
+   var height = totalArea / w || 0,
+       top = coord.top,
        left = 0;
-   
+
    for(var i=0, l=ch.length; i<l; i++) {
      var chi = ch[i];
-     var w = height == 0 ? 0 : chi._area / height;
+     var w = chi._area / height || 0;
      chi.getPos(prop).setc(coord.left + left, top);
      chi.setData('width', w, prop);
      chi.setData('height', height, prop);

--- a/Source/Visualizations/Spacetree.js
+++ b/Source/Visualizations/Spacetree.js
@@ -341,6 +341,8 @@ $jit.ST= (function() {
             };
             if(move.enable) {
                 this.geom.translate(node.endPos.add(offset).$scale(-1), "end");
+            } else {
+                this.geom.translate($C(offset.x, offset.y).$scale(-1), "end");
             }
             this.fx.animate($.merge(this.controller, { modes: ['linear'] }, onComplete));
          },

--- a/Source/Visualizations/Spacetree.js
+++ b/Source/Visualizations/Spacetree.js
@@ -292,11 +292,18 @@ $jit.ST= (function() {
 
        reposition: function() {
             this.graph.computeLevels(this.root, 0, "ignore");
-             this.geom.setRightLevelToShow(this.clickedNode, this.canvas);
+            this.geom.setRightLevelToShow(this.clickedNode, this.canvas);
             this.graph.eachNode(function(n) {
                 if(n.exist) n.drawn = true;
             });
             this.compute('end');
+            if (this.clickedNode) {
+              var offset = {
+                  x: this.config.offsetX || 0,
+                  y: this.config.offsetY || 0
+              };
+              this.geom.translate(this.clickedNode.endPos.add(offset).$scale(-1), 'end');
+            }
         },
         
         requestNodes: function(node, onComplete) {


### PR DESCRIPTION
When a node is really small, its computed width is rounded to 0, and its coordinates contains 'NaN' values.

As a result, the treemap cannot be displayed.
