### PR TITLE
[TreeMap] Small bugfixes

### DIFF
--- a/Source/Layouts/Layouts.TM.js
+++ b/Source/Layouts/Layouts.TM.js
@@ -105,8 +105,8 @@ Layouts.TM.Area = {
     root.setData('height', height, prop);
     //create a coordinates object
     var coord = {
-        'top': -height/2 + config.titleHeight,
-        'left': -width/2,
+        'top': -height/2 + config.titleHeight + offst / 2,
+        'left': -width/2 + offst / 2,
         'width': offwdth,
         'height': offhght - config.titleHeight
     };
@@ -261,8 +261,8 @@ Layouts.TM.Squarified = new Class({
        coord = {
          'width': width,
          'height': height,
-         'top': chipos.y + config.titleHeight,
-         'left': chipos.x
+         'top': chipos.y + config.titleHeight + offst / 2,
+         'left': chipos.x + offst / 2
        };
        this.computePositions(chi, coord, prop);
      }
@@ -415,8 +415,8 @@ Layouts.TM.Strip = new Class({
          coord = {
            'width': width,
            'height': height,
-           'top': chipos.y + config.titleHeight,
-           'left': chipos.x
+           'top': chipos.y + config.titleHeight + offst / 2,
+           'left': chipos.x + offst / 2
          };
          this.computePositions(chi, coord, prop);
        }

--- a/Source/Visualizations/Treemap.js
+++ b/Source/Visualizations/Treemap.js
@@ -238,7 +238,7 @@ TM.Base = {
             n.setData('alpha', 1, 'end');
           }, "ignore");
           that.fx.animate({
-            duration: 500,
+            duration: that.config.duration / 3,
             modes:['node-property:alpha'],
             onComplete: function() {
               //compute end positions
@@ -249,7 +249,7 @@ TM.Base = {
               that.clickedNode = previousClickedNode;
               that.fx.animate({
                 modes:['linear', 'node-property:width:height'],
-                duration: 1000,
+                duration: 2 * that.config.duration / 3,
                 onComplete: function() { 
                   that.busy = false;
                   //TODO(nico) check comment above
@@ -326,7 +326,7 @@ TM.Base = {
       this.clickedNode = previousClickedNode;
       this.fx.animate({
         modes:['linear', 'node-property:width:height'],
-        duration: 1000,
+        duration: 2 * this.config.duration / 3,
         onComplete: function() {
           //animate the parent subtree
           that.clickedNode = clickedNode;
@@ -340,7 +340,7 @@ TM.Base = {
             node.setData('alpha', 1);
           }, "ignore");
           that.fx.animate({
-            duration: 500,
+            duration: that.config.duration / 3,
             modes:['node-property:alpha'],
             onComplete: function() {
               callback.onComplete();


### PR DESCRIPTION
- The offset spacing is now centered around every box. This partly solves issue #64
- The duration parameter now also applies to the enter and out animations. This fixes issue #71
