### PR TITLE
onBeforeRemoveNode method

### DIFF
--- a/Source/Graph/Graph.Op.js
+++ b/Source/Graph/Graph.Op.js
@@ -63,7 +63,10 @@ Graph.Op = {
         var i, that, nodeObj;
         switch(options.type) {
             case 'nothing':
-                for(i=0; i<n.length; i++) viz.graph.removeNode(n[i]);
+                for(i=0; i<n.length; i++) {
+                    options.onBeforeRemoveNode(viz.graph.getNode(n[i]));
+                    viz.graph.removeNode(n[i]);
+                }
                 break;
             
             case 'replot':

--- a/Source/Graph/Graph.js
+++ b/Source/Graph/Graph.js
@@ -1073,6 +1073,7 @@ Graph.Util = {
         var queue = [graph.getNode(id)];
         while(queue.length != 0) {
             var node = queue.pop();
+            if (!node) return;
             node._flag = true;
             action(node, node._depth);
             this.eachAdjacency(node, function(adj) {
@@ -1089,6 +1090,7 @@ Graph.Util = {
        Method: eachLevel
     
        Iterates over a node's subgraph applying *action* to the nodes of relative depth between *levelBegin* and *levelEnd*.
+       In case you need to break the iteration, *action* should return false.
        
        Also implemented by:
        
@@ -1103,18 +1105,20 @@ Graph.Util = {
 
     */
     eachLevel: function(node, levelBegin, levelEnd, action, flags) {
-        var d = node._depth, filter = this.filter(flags), that = this;
+        var d = node._depth, filter = this.filter(flags), that = this, shouldContinue = true;
         levelEnd = levelEnd === false? Number.MAX_VALUE -d : levelEnd;
         (function loopLevel(node, levelBegin, levelEnd) {
-            var d = node._depth;
-            if(d >= levelBegin && d <= levelEnd && filter(node)) action(node, d);
-            if(d < levelEnd) {
+            if(!shouldContinue) return;
+            var d = node._depth, ret;
+            if(d >= levelBegin && d <= levelEnd && filter(node)) ret = action(node, d);
+            if(typeof ret !== "undefined") shouldContinue = ret;
+            if(shouldContinue && d < levelEnd) {
                 that.eachAdjacency(node, function(adj) {
                     var n = adj.nodeTo;
                     if(n._depth > d) loopLevel(n, levelBegin, levelEnd);
                 });
             }
-        })(node, levelBegin + d, levelEnd + d);      
+        })(node, levelBegin + d, levelEnd + d);
     },
 
     /*

--- a/Source/Options/Options.Controller.js
+++ b/Source/Options/Options.Controller.js
@@ -66,7 +66,8 @@
    onAfterPlotNode(node) - This method is triggered right after plotting each <Graph.Node>.
    onBeforePlotLine(adj) - This method is triggered right before plotting a <Graph.Adjacence>. This method is useful for adding some styles to a particular edge before being plotted.
    onAfterPlotLine(adj) - This method is triggered right after plotting a <Graph.Adjacence>.
-
+   onBeforeRemoveNode(node) - This method is triggered right before removing each <Graph.Node>.
+   
     *Used in <ST>, <TM.Base> and <Icicle> visualizations*
     
     request(nodeId, level, onComplete) - This method is used for buffering information into the visualization. When clicking on an empty node, the visualization will make a request for this node's subtrees, specifying a given level for this subtree (defined by _levelsToShow_). Once the request is completed, the onComplete callback should be called with the given result. This is useful to provide on-demand information into the visualizations withought having to load the entire information from start. The parameters used by this method are _nodeId_, which is the id of the root of the subtree to request, _level_ which is the depth of the subtree to be requested (0 would mean just the root node). _onComplete_ is an object having the callback method _onComplete.onComplete(json)_ that should be called once the json has been retrieved.  
@@ -75,14 +76,15 @@
 Options.Controller = {
   $extend: true,
   
-  onBeforeCompute: $.empty,
-  onAfterCompute:  $.empty,
-  onCreateLabel:   $.empty,
-  onPlaceLabel:    $.empty,
-  onComplete:      $.empty,
-  onBeforePlotLine:$.empty,
-  onAfterPlotLine: $.empty,
-  onBeforePlotNode:$.empty,
-  onAfterPlotNode: $.empty,
+  onBeforeCompute:   $.empty,
+  onAfterCompute:    $.empty,
+  onCreateLabel:     $.empty,
+  onPlaceLabel:      $.empty,
+  onComplete:        $.empty,
+  onBeforePlotLine:  $.empty,
+  onAfterPlotLine:   $.empty,
+  onBeforePlotNode:  $.empty,
+  onAfterPlotNode:   $.empty,
+  onBeforeRemoveNode:$.empty,
   request:         false
 };


### PR DESCRIPTION
Added a onBeforeRemoveNode method which is triggered right before removing a Graph.Node.

Use case is when each ST node has an associated complex DOM element (think of an overlay panel) and when removing a node (with children) the only hook to delete the DOM elements would be the onComplete (when removal is animated), which is only fired for that specific node and not for each one of the removed nodes.

Thanks for including this change.
