### PR TITLE
Update Source/Loader/Loader.js

### DIFF
--- a/Source/Loader/Loader.js
+++ b/Source/Loader/Loader.js
@@ -16,11 +16,14 @@ var Loader = {
             //make tree
             (function (ans, json) {
                 ans.addNode(json);
-                if(json.children) {
+                if(json.children && json.children.length) {
                   for(var i=0, ch = json.children; i<ch.length; i++) {
                     ans.addAdjacence(json, ch[i]);
                     arguments.callee(ans, ch[i]);
                   }
+                }
+                else {
+                  ans.addNode(json[i]);
                 }
             })(ans, json);
         else


### PR DESCRIPTION
Problem description:
    When trying to load a tree with a single node (only the root node), nothing is drawn.

Problem cause:
    Loader determines if the json represents a graph or a tree by examining the received json - if it is an array, it 
    is considered to be a graph, otherwise a tree. In case of a tree, Loader creates adjacencies (and not nodes), 
    which in turn creates the nodes. When the root node has no children, no adjacencies are created, thus the 
    root is also not created.

Solution description:
    In case of a tree, Loader checks 1st if the root json node has children. If it does, Loader works as before. If 
    not, the root is explicitly created.
