### PR TITLE
Prevent hiding of partially visible labels

### DIFF
--- a/Source/Graph/Graph.Label.js
+++ b/Source/Graph/Graph.Label.js
@@ -273,8 +273,8 @@ Graph.Label.DOM = new Class({
     */
     fitsInCanvas: function(pos, canvas) {
       var size = canvas.getSize();
-      if(pos.x >= size.width || pos.x < 0
-         || pos.y >= size.height || pos.y < 0) return false;
+        if (pos.x >= size.width || pos.x < -this.viz.geom.node.width
+         || pos.y >= size.height || pos.y < -this.viz.geom.node.height) return false;
        return true;
     }
 });

--- a/Source/Graph/Graph.Label.js
+++ b/Source/Graph/Graph.Label.js
@@ -273,8 +273,14 @@ Graph.Label.DOM = new Class({
     */
     fitsInCanvas: function(pos, canvas) {
       var size = canvas.getSize();
-        if (pos.x >= size.width || pos.x < -this.viz.geom.node.width
-         || pos.y >= size.height || pos.y < -this.viz.geom.node.height) return false;
+      if (pos.w && pos.h) {
+      	if (pos.x >= size.width || pos.x < -pos.w
+         || pos.y >= size.height || pos.y < -pos.h) return false;      	
+      }
+      else {
+      	if (pos.x >= size.width || pos.x < 0
+         || pos.y >= size.height || pos.y < 0) return false;
+      }
        return true;
     }
 });

--- a/Source/Visualizations/Spacetree.js
+++ b/Source/Visualizations/Spacetree.js
@@ -1302,8 +1302,8 @@ $jit.ST.Label.DOM = new Class({
             }
         } else throw "align: not implemented";
 
-		labelPos.w=w*sx;
-		labelPos.h=h*sy;
+		labelPos.w=w;
+		labelPos.h=h;
 
         var style = tag.style;
         style.left = labelPos.x + 'px';

--- a/Source/Visualizations/Spacetree.js
+++ b/Source/Visualizations/Spacetree.js
@@ -1302,6 +1302,9 @@ $jit.ST.Label.DOM = new Class({
             }
         } else throw "align: not implemented";
 
+		labelPos.w=w*sx;
+		labelPos.h=h*sy;
+
         var style = tag.style;
         style.left = labelPos.x + 'px';
         style.top  = labelPos.y + 'px';


### PR DESCRIPTION
Updates fitsInCanvas so that labels will only be hidden if the node is entirely outside the visible area
