### PR TITLE
Fix tooltips positions on pages with a scrollbar.

### DIFF
--- a/Source/Extras/Extras.js
+++ b/Source/Extras/Extras.js
@@ -476,10 +476,21 @@ Extras.Classes.Tips = new Class({
         style = tip.style, 
         cont = this.config;
     style.display = '';
-    //get window dimensions
-    var win = {
-      'height': document.body.clientHeight,
-      'width': document.body.clientWidth
+    //get viewport dimensions
+    var elem = document.compatMode === "CSS1Compat" && document.documentElement ||
+               document.body ||
+               document.documentElement;
+    var view = {
+      'width': elem.clientWidth,
+      'height': elem.clientHeight,
+      'x': window.pageXOffset ||
+           document.documentElement && document.documentElement.scrollLeft ||
+           document.body && document.body.scrollLeft ||
+           0,
+      'y': window.pageYOffset ||
+           document.documentElement && document.documentElement.scrollTop ||
+           document.body && document.body.scrollTop ||
+           0
     };
     //get tooltip dimensions
     var obj = {
@@ -488,9 +499,9 @@ Extras.Classes.Tips = new Class({
     };
     //set tooltip position
     var x = cont.offsetX, y = cont.offsetY;
-    style.top = ((pos.y + y + obj.height > win.height)?  
+    style.top = ((pos.y + obj.height + y > view.height + view.y)?
         (pos.y - obj.height - y) : pos.y + y) + 'px';
-    style.left = ((pos.x + obj.width + x > win.width)? 
+    style.left = ((pos.x + obj.width + x > view.width + view.x)?
         (pos.x - obj.width - x) : pos.x + x) + 'px';
   },
   


### PR DESCRIPTION
Better viewport detection.

There are two bugs in current tooltips:

1) Incorrect tooltip positioning.
Can be observed on pages with scrollbars.
On http://thejit.org/static/v20/Jit/Examples/Icicle/example2.html:
Horizontal placement is wrong (left instead of right): http://wstaw.org/m/2012/07/11/plasma-windowedEt2982.png
Vertical placement is wrong (down instead of up): http://wstaw.org/m/2012/07/11/plasma-windowedlx2982.png
Vertical placement is also wrong as horizontal in the first screenshot (up, when should be down) if body height is forced to 100% in css.

2) Incorrect tooltip widths: http://wstaw.org/m/2012/07/11/plasma-windowednt2982.png
Not affected by this patch.

This patch fixes the first bug. After the patch is applied, the tooltip position is correct (bottom-right if possible in the current viewport).
