### PR TITLE
Update build to create example folders.

### DIFF
--- a/make.py
+++ b/make.py
@@ -91,7 +91,9 @@ def make_example(viz, ex, i, count, fancy):
     extras = model['Extras'][:]
     example = 'example' + str(count)
     strdir = 'Examples/' + viz + '/'
-    
+    if not path.exists(strdir):
+        mkdir(strdir)
+
     #insert the example js file
     fcommon = open('Tests/js/common.js', 'r')
     ftest = open('Tests/' + viz + '/test' + stri + '.js', 'r')


### PR DESCRIPTION
On a windows system, the build process needs to create the example
sub folders, in order to progress.

Signed-off-by: helibobs helenm.666@hotmail.co.uk
