### PR TITLE
indexOf method called on an object that does not implement it

### DIFF
--- a/Source/Core/Core.js
+++ b/Source/Core/Core.js
@@ -139,7 +139,7 @@ $.each = function(iterable, fn) {
 };
 
 $.indexOf = function(array, item) {
-  if(Array.indexOf) return array.indexOf(item);
+  if(array.indexOf) return array.indexOf(item);
   for(var i=0,l=array.length; i<l; i++) {
     if(array[i] === item) return i;
   }


### PR DESCRIPTION
Line 142 of Core.js checks the Array object definition for the indexOf method, and if found it calls the indexOf method on the array parameter passed to the function.  There is nothing checking to make sure that array (the method parameter) is in fact an Array, which resulted in problems when using the Area Chart in IE 8.  

I changed the $.indexOf method in Core.js to check the parameter (array) for the indexOf method rather than the definition of Array.

Since I've done this on company time, legal is requiring that I include a copyright notice on the (admittedly very small) update...

MIT License

© 2012 State Farm Mutual Automobile Insurance Company

Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 

The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.

THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
