### PR TITLE
Adding a detection of the HTMLDocument for IE7/8 compatibility

### DIFF
--- a/Source/Core/Core.js
+++ b/Source/Core/Core.js
@@ -108,6 +108,7 @@ $.type = function(elem) {
   var type = $.type.s.call(elem).match(/^\[object\s(.*)\]$/)[1].toLowerCase();
   if(type != 'object') return type;
   if(elem && elem.$$family) return elem.$$family;
+  if(elem && elem.nodeType == 9) return 'htmldocument';
   return (elem && elem.nodeName && elem.nodeType == 1)? 'element' : type;
 };
 $.type.s = Object.prototype.toString;


### PR DESCRIPTION
#126

The only change I added is an aditionnal detection when the type if object to check on the nodeType and detect if it's a HTMLDocument.

Currently in IE7/8, it will return [object Object] as the type, which is interpreted as an Object and will break when $.unlink is called.

This behaviour is breaking JQuery.spacetree in IE 7/8.

Other browser correctly return [object HtmlDocument](IE 9, Chrome and Firefox)
