### PR TITLE
This allows changing the crusor while draging

### DIFF
--- a/Source/Extras/Extras.js
+++ b/Source/Extras/Extras.js
@@ -739,6 +739,8 @@ Extras.Classes.Navigation = new Class({
   
   onMouseDown: function(e, win, eventInfo) {
     if(!this.config.panning) return;
+    e.preventDefault();
+    $.addClass(this.canvas.getElement(), 'grabbing');
     if(this.config.panning == 'avoid nodes' && (this.dom? this.isLabel(e, win) : eventInfo.getNode())) return;
     this.pressed = true;
     this.pos = eventInfo.getPos();
@@ -776,6 +778,7 @@ Extras.Classes.Navigation = new Class({
   
   onMouseUp: function(e, win, eventInfo, isRightClick) {
     if(!this.config.panning) return;
+    $.removeClass(this.canvas.getElement(), 'grabbing');
     this.pressed = false;
   }
 });


### PR DESCRIPTION
This allows changing the crusor while draging, e.g.
# infovisContainer-canvaswidget.grabbing {

cursor: -webkit-grab;
}
# infovisContainer-canvaswidget.grabbing {

cursor: -webkit-grabbing;
}

e.preventDefault() is needed for some browsers (e.g. webkit based) which
default operation of dragging is selection (hence the corsor shown).
