### PR TITLE
Force Directed Graph:Edges cannot be dragged when Navigation is enabled

### DIFF
--- a/Source/Extras/Extras.js
+++ b/Source/Extras/Extras.js
@@ -741,7 +741,7 @@ Extras.Classes.Navigation = new Class({
     if(!this.config.panning) return;
     e.preventDefault();
     $.addClass(this.canvas.getElement(), 'grabbing');
-    if(this.config.panning == 'avoid nodes' && (this.dom? this.isLabel(e, win) : eventInfo.getNode())) return;
+    if(this.config.panning == 'avoid nodes' && (this.dom? this.isLabel(e, win) : (eventInfo.getNode() || eventInfo.getEdge()))) return;
     this.pressed = true;
     this.pos = eventInfo.getPos();
     var canvas = this.canvas,


### PR DESCRIPTION
I'm using Force Directed Graph and testing my experimental implementation of dragging edges.

I cannot drag edges when I set true to Navigation.enable even if 'avoid nodes' is specified for Navigation.panning.

It seems that changeing the following line (1) to the line (2) in the onMouseDown function of Extras.Classes.Navigation solves this issue:

```
if(this.config.panning == 'avoid nodes' && (this.dom? this.isLabel(e, win) : eventInfo.getNode())) return; // (1)

if(this.config.panning == 'avoid nodes' && (this.dom? this.isLabel(e, win) : (eventInfo.getNode() || eventInfo.getEdge()))) return; // (2)
```

Or are there any panning settings like 'avoid edges' or 'avoid nodes and edges'?

Thanks.
