### PR TITLE
Fix nodeFx bug

### DIFF
--- a/Source/Graph/Graph.Plot.js
+++ b/Source/Graph/Graph.Plot.js
@@ -475,6 +475,10 @@ Graph.Plot = {
       (end code)    
    */
    nodeFx: function(opt) {
+     if (this.nodeFxAnimation == undefined) {
+       this.nodeFxAnimation = new Animation();
+     }
+
      var viz = this.viz,
          graph  = viz.graph,
          animation = this.nodeFxAnimation,


### PR DESCRIPTION
When calling `nodeFx()` on an RGraph, I was getting the error `TypeError: Cannot call method 'stopTimer' of undefined`.  It looks like the nodeFxAnimation is normally initialized on hover, but otherwise didn't exist.

This fixes the issue, allowing nodeFx to be invoked directly.
