### PR TITLE
Added optional parameter 'id' to JSON

### DIFF
--- a/Source/Visualizations/BarChart.js
+++ b/Source/Visualizations/BarChart.js
@@ -536,8 +536,11 @@ $jit.BarChart = new Class({
       var val = values[i]
       var valArray = $.splat(values[i].values);
       var acum = 0;
+      if (typeof val.id == 'undefined') {
+        val.id = val.label;
+      } 
       ch.push({
-        'id': prefix + val.label,
+        'id': prefix + val.id,
         'name': val.label,
         'data': {
           'value': valArray,


### PR DESCRIPTION
Added optional parameter 'id' to Jit BarChart, because the previous implementation was not allowing two or more same labels.
If an id is not specified, it is using key => value, where key is the label, and for two same labels it would not count the second one.
If an id is specified, it will use id => value.

E.g. one can use the following JSON code to display the same label:
'values': [
{
  'id':'a',
  'label': 'date A',
  'values': [20, 40, 15, 5]
}, 
{
  'id':'b',
  'label': 'date A',
  'values': [30, 10, 45, 10]
}]
