### PR TITLE
fixed missing touch event raising an exception

### DIFF
--- a/Source/Options/Options.Events.js
+++ b/Source/Options/Options.Events.js
@@ -90,5 +90,6 @@ Options.Events = {
   onTouchStart: $.empty,
   onTouchMove: $.empty,
   onTouchEnd: $.empty,
+  onTouchCancel: $.empty,
   onMouseWheel: $.empty
 };


### PR DESCRIPTION
this patch fixes

```
jit.js:2293 TypeError: 'undefined' is not a function (evaluating 'this.config.onTouchCancel(this.touched, event, evt)')
```
