### PR TITLE
RTL support to squarified treemaps

### DIFF
--- a/Source/Core/Core.js
+++ b/Source/Core/Core.js
@@ -412,6 +412,25 @@ $.getPos = function(elem) {
   }
 };
 
+/*
+  Method: $.getDir
+
+  Get or compute the direction style (right-to-left or left-to-right) of an element (or document body by default if no element is provided). Returns the direction as a string "rtl" / "ltr".
+
+  Parameters:
+
+  elem - (optional) The element to check direction of (document.body if undefined).
+*/
+$.getDir = function(elem) {
+    var element = document.getElementById(elem) || document.body;
+    if (element.currentStyle)
+	var dir = element.currentStyle.direction;
+    else if (window.getComputedStyle)
+	var dir = document.defaultView.getComputedStyle(element, null)
+	              .getPropertyValue('direction');
+    return dir;
+};
+
 $.event = {
   get: function(e, win) {
     win = win || window;

--- a/Source/Layouts/Layouts.TM.js
+++ b/Source/Layouts/Layouts.TM.js
@@ -343,7 +343,10 @@ layoutV: function(ch, w, coord, prop) {
    for(var i=0, l=ch.length; i<l; i++) {
      var h = rnd(ch[i]._area / width) || 0;
      var chi = ch[i];
-     chi.getPos(prop).setc(coord.left, coord.top + top);
+
+     var posx = $.getDir() === 'rtl' ? (-1 * coord.left)-width : coord.left;
+
+     chi.getPos(prop).setc(posx, coord.top + top);
      chi.setData('width', width, prop);
      chi.setData('height', h, prop);
      top += h;
@@ -370,7 +373,11 @@ layoutV: function(ch, w, coord, prop) {
    for(var i=0, l=ch.length; i<l; i++) {
      var chi = ch[i];
      var w = chi._area / height || 0;
-     chi.getPos(prop).setc(coord.left + left, top);
+
+     var posx = $.getDir() === 'rtl' ? 
+	   (-1 * (coord.left + left)) - w : coord.left + left;
+
+     chi.getPos(prop).setc(posx, top);
      chi.setData('width', w, prop);
      chi.setData('height', height, prop);
      left += w;
@@ -384,7 +391,29 @@ layoutV: function(ch, w, coord, prop) {
    ans.dim = Math.min(ans.width, ans.height);
    if(ans.dim != ans.width) this.layout.change();
    return ans;
+ },
+
+ /*
+    layoutLast
+ 
+   Performs the layout of the last computed sibling with respect to direction
+ 
+    Parameters:
+
+       ch - An array of nodes.  
+       w - A fixed dimension where nodes will be layed out.
+     coord - A coordinates object specifying width, height, left and top style properties (assumes ltr direction).
+ */
+ layoutLast: function(ch, w, coord, prop) {
+   var child = ch[0];
+
+   var posx = $.getDir() === 'rtl' ? -1*coord.left-coord.width: coord.left;
+
+   child.getPos(prop).setc(posx, coord.top);
+   child.setData('width', coord.width, prop);
+   child.setData('height', coord.height, prop);
  }
+
 });
 
 Layouts.TM.Strip = new Class({


### PR DESCRIPTION
Added rtl support to the squarified treemap, so that when direction is rtl the larger the area the farther to the right the tile is (instead of the other way around).
