### PR TITLE
Use /demos.html instead of /demos/ (gh-pages)

### DIFF
--- a/static/v20/js/home.js
+++ b/static/v20/js/home.js
@@ -21,7 +21,7 @@ window.addEvent('domready', function() {
                 'class': 'tag'
             });
             var alink = new Element('a', {
-              'href': 'demos/',
+              'href': 'demos.html',
               'title': 'Try the demos'
             });
             images[i++].inject(alink);


### PR DESCRIPTION
The image marquee on the home page changes the link from /demos.html to /demos/. The latter doesn’t work. This fixes it.
