### PR TITLE
Clear out clickedNode reference on data load

### DIFF
--- a/Source/Loader/Loader.js
+++ b/Source/Loader/Loader.js
@@ -188,6 +188,10 @@ var Loader = {
       } else {
         this.root = json[i? i : 0].id;
       }
+      // Clear reference to no-longer-valid node
+      if(this.clickedNode) {
+        this.clickedNode = null;
+      }
     },
     
     /*


### PR DESCRIPTION
I ran into an issue when reloading the data in a TreeMap. If I clicked on a node to set a new root, and then reloaded the data, compute() would try to set the root to the old value of this.clickedNode, resulting in an error and failure to redraw the graph. 

This PR fixes the issue by clearing out the reference to clickedNode when loading data. The side effect is that reloading data and refreshing the plot will always bring you back to the root node, even if there's a new node with the same ID in the updated data. 
