### PR TITLE
Fix issue where uppercase style names weren't read in IE8

### DIFF
--- a/Extras/excanvas.js
+++ b/Extras/excanvas.js
@@ -456,7 +456,7 @@ if (!document.createElement('canvas').getContext) {
 
     var str, alpha = 1;
 
-    styleString = String(styleString).toLocaleLowerCase();
+    styleString = String(styleString).toLowerCase();
     if (styleString.charAt(0) == '#') {
       str = styleString;
     } else if (/^rgb/.test(styleString)) {

--- a/Extras/excanvas.js
+++ b/Extras/excanvas.js
@@ -456,7 +456,7 @@ if (!document.createElement('canvas').getContext) {
 
     var str, alpha = 1;
 
-    styleString = String(styleString);
+    styleString = String(styleString).toLocaleLowerCase();
     if (styleString.charAt(0) == '#') {
       str = styleString;
     } else if (/^rgb/.test(styleString)) {


### PR DESCRIPTION
Converts all style strings to lowercase so that correct `colorData` hex value can be plugged in for named colors in IE8.

Previously the following would color nodes with a weird black color in IE8:

```
Node: {
            height: 60,
            width: 180,
            type: 'rectangle',
            color: 'LightCyan',
            overridable: true
        }
```

but this would work:

```
Node: {
            height: 60,
            width: 180,
            type: 'rectangle',
            color: 'lightcyan',
            overridable: true
        }
```
